### PR TITLE
Introduce Span overloads for Regex APIs

### DIFF
--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.cs
@@ -15,6 +15,7 @@ namespace System.Text.RegularExpressions
         public int Index { get { throw null; } }
         public int Length { get { throw null; } }
         public string Value { get { throw null; } }
+        public ReadOnlySpan<char> ValueSpan { get { throw null; } }
         public override string ToString() { throw null; }
     }
     public partial class CaptureCollection : System.Collections.Generic.ICollection<System.Text.RegularExpressions.Capture>, System.Collections.Generic.IEnumerable<System.Text.RegularExpressions.Capture>, System.Collections.Generic.IList<System.Text.RegularExpressions.Capture>, System.Collections.Generic.IReadOnlyCollection<System.Text.RegularExpressions.Capture>, System.Collections.Generic.IReadOnlyList<System.Text.RegularExpressions.Capture>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
@@ -99,6 +100,7 @@ namespace System.Text.RegularExpressions
         public virtual System.Text.RegularExpressions.GroupCollection Groups { get { throw null; } }
         public System.Text.RegularExpressions.Match NextMatch() { throw null; }
         public virtual string Result(string replacement) { throw null; }
+        public virtual bool TryResult(string replacement, Span<char> destination, out int charsWritten) { throw null; }
         public static System.Text.RegularExpressions.Match Synchronized(System.Text.RegularExpressions.Match inner) { throw null; }
     }
     public partial class MatchCollection : System.Collections.Generic.ICollection<System.Text.RegularExpressions.Match>, System.Collections.Generic.IEnumerable<System.Text.RegularExpressions.Match>, System.Collections.Generic.IList<System.Text.RegularExpressions.Match>, System.Collections.Generic.IReadOnlyCollection<System.Text.RegularExpressions.Match>, System.Collections.Generic.IReadOnlyList<System.Text.RegularExpressions.Match>, System.Collections.ICollection, System.Collections.IEnumerable, System.Collections.IList
@@ -134,6 +136,12 @@ namespace System.Text.RegularExpressions
     public delegate string MatchEvaluator(System.Text.RegularExpressions.Match match);
     public partial class Regex : System.Runtime.Serialization.ISerializable
     {
+        public ref struct SplitEnumerator
+        {
+            public ReadOnlySpan<char> Current { get { throw null; } }
+            public SplitEnumerator GetEnumerator() { throw null; }
+            public bool MoveNext() { throw null; }
+        }
         protected internal System.Collections.Hashtable caps;
         protected internal System.Collections.Hashtable capnames;
         protected internal int capsize;
@@ -157,48 +165,62 @@ namespace System.Text.RegularExpressions
         public System.Text.RegularExpressions.RegexOptions Options { get { throw null; } }
         public bool RightToLeft { get { throw null; } }
         public static string Escape(string str) { throw null; }
+        public static bool TryEscape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten) { throw null; }
         public string[] GetGroupNames() { throw null; }
         public int[] GetGroupNumbers() { throw null; }
         public string GroupNameFromNumber(int i) { throw null; }
         public int GroupNumberFromName(string name) { throw null; }
         protected void InitializeReferences() { }
         public bool IsMatch(string input) { throw null; }
+        public bool IsMatch(ReadOnlySpan<char> input) { throw null; }
         public bool IsMatch(string input, int startat) { throw null; }
         public static bool IsMatch(string input, string pattern) { throw null; }
         public static bool IsMatch(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
         public static bool IsMatch(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+        public static bool IsMatch(ReadOnlySpan<char> input, string pattern, System.Text.RegularExpressions.RegexOptions options = System.Text.RegularExpressions.RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
         public System.Text.RegularExpressions.Match Match(string input) { throw null; }
+        public System.Text.RegularExpressions.Match Match(ReadOnlyMemory<char> input) { throw null; }
         public System.Text.RegularExpressions.Match Match(string input, int startat) { throw null; }
         public System.Text.RegularExpressions.Match Match(string input, int beginning, int length) { throw null; }
         public static System.Text.RegularExpressions.Match Match(string input, string pattern) { throw null; }
         public static System.Text.RegularExpressions.Match Match(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
         public static System.Text.RegularExpressions.Match Match(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+        public static System.Text.RegularExpressions.Match Match(ReadOnlyMemory<char> input, string pattern, System.Text.RegularExpressions.RegexOptions options = RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
         public System.Text.RegularExpressions.MatchCollection Matches(string input) { throw null; }
+        public System.Text.RegularExpressions.MatchCollection Matches(ReadOnlyMemory<char> input) { throw null; }
         public System.Text.RegularExpressions.MatchCollection Matches(string input, int startat) { throw null; }
         public static System.Text.RegularExpressions.MatchCollection Matches(string input, string pattern) { throw null; }
         public static System.Text.RegularExpressions.MatchCollection Matches(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
         public static System.Text.RegularExpressions.MatchCollection Matches(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+        public static System.Text.RegularExpressions.MatchCollection Matches(ReadOnlyMemory<char> input, string pattern, System.Text.RegularExpressions.RegexOptions options = RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
         public string Replace(string input, string replacement) { throw null; }
         public string Replace(string input, string replacement, int count) { throw null; }
+        public bool TryReplace(ReadOnlySpan<char> input, string replacement, Span<char> destination, out int charsWritten, int count = -1) { throw null; }
         public string Replace(string input, string replacement, int count, int startat) { throw null; }
         public static string Replace(string input, string pattern, string replacement) { throw null; }
         public static string Replace(string input, string pattern, string replacement, System.Text.RegularExpressions.RegexOptions options) { throw null; }
         public static string Replace(string input, string pattern, string replacement, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+        public static bool TryReplace(ReadOnlySpan<char> input, string pattern, string replacement, Span<char> destination, out int charsWritten, System.Text.RegularExpressions.RegexOptions options = System.Text.RegularExpressions.RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
         public static string Replace(string input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator) { throw null; }
         public static string Replace(string input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator, System.Text.RegularExpressions.RegexOptions options) { throw null; }
         public static string Replace(string input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+        public static bool TryReplace(ReadOnlySpan<char> input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator, Span<char> destination, out int charsWritten, System.Text.RegularExpressions.RegexOptions options = System.Text.RegularExpressions.RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
         public string Replace(string input, System.Text.RegularExpressions.MatchEvaluator evaluator) { throw null; }
         public string Replace(string input, System.Text.RegularExpressions.MatchEvaluator evaluator, int count) { throw null; }
+        public bool TryReplace(ReadOnlySpan<char> input, System.Text.RegularExpressions.MatchEvaluator evaluator, Span<char> destination, out int charsWritten, int count = -1) { throw null; }
         public string Replace(string input, System.Text.RegularExpressions.MatchEvaluator evaluator, int count, int startat) { throw null; }
         public string[] Split(string input) { throw null; }
         public string[] Split(string input, int count) { throw null; }
         public string[] Split(string input, int count, int startat) { throw null; }
+        public SplitEnumerator Split(ReadOnlySpan<char> input, int count = 0) { throw null; }
         public static string[] Split(string input, string pattern) { throw null; }
         public static string[] Split(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
         public static string[] Split(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+        public static SplitEnumerator Split(ReadOnlySpan<char> input, string pattern, RegexOptions options = RegexOptions.None, TimeSpan? matchTimeout = null) { throw null; }
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { }
         public override string ToString() { throw null; }
         public static string Unescape(string str) { throw null; }
+        public static bool TryUnescape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten) { throw null; }
         protected bool UseOptionC() { throw null; }
         protected bool UseOptionR() { throw null; }
         protected internal static void ValidateMatchTimeout(System.TimeSpan matchTimeout) { }

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -9,6 +9,8 @@
     <Configurations>netcoreapp-Debug;netcoreapp-Release;netcoreappaot-Debug;netcoreappaot-Release;uap-Windows_NT-Debug;uap-Windows_NT-Release</Configurations>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Buffers\MemoryOrPinnedSpan.cs" />
+    <Compile Include="System\Buffers\SpanHelper.cs" />
     <Compile Include="System\Collections\Generic\ValueListBuilder.Pop.cs" />
     <Compile Include="System\Collections\HashtableExtensions.cs" />
     <Compile Include="System\Text\RegularExpressions\Capture.cs" />
@@ -43,6 +45,7 @@
     <Compile Include="System\Text\RegularExpressions\RegexRunnerFactory.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexTree.cs" />
     <Compile Include="System\Text\RegularExpressions\RegexWriter.cs" />
+    <Compile Include="System\Text\ValueStringBuilder.Reverse.cs" />
     <!-- Common or Common-branched source files -->
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
@@ -53,7 +56,6 @@
     <Compile Include="$(CommonPath)\CoreLib\System\Text\ValueStringBuilder.cs">
       <Link>Common\System\Text\ValueStringBuilder.cs</Link>
     </Compile>
-    <Compile Include="System\Text\ValueStringBuilder.Reverse.cs" />
   </ItemGroup>
   <!-- Files that enable compiled feature -->
   <ItemGroup Condition="'$(TargetGroup)' == 'netcoreapp'">

--- a/src/System.Text.RegularExpressions/src/System/Buffers/MemoryOrPinnedSpan.cs
+++ b/src/System.Text.RegularExpressions/src/System/Buffers/MemoryOrPinnedSpan.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    internal unsafe readonly struct MemoryOrPinnedSpan<T>
+    {
+        private readonly ReadOnlyMemory<T> _memory;
+        private readonly char* _ptr;
+        private readonly int _length;
+
+        public MemoryOrPinnedSpan(ReadOnlyMemory<T> memory)
+        {
+            _memory = memory;
+            _length = memory.Length;
+            _ptr = null;
+        }
+
+        public MemoryOrPinnedSpan(char* pinnedSpan, int length)
+        {
+            _ptr = pinnedSpan;
+            _length = length;
+            _memory = null;
+        }
+
+        public int Length => _length;
+
+        public ReadOnlySpan<T> Span => (_ptr != null) ? new ReadOnlySpan<T>(_ptr, Length) : _memory.Span;
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Buffers/SpanHelper.cs
+++ b/src/System.Text.RegularExpressions/src/System/Buffers/SpanHelper.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.Buffers
+{
+    internal static class SpanHelper
+    {
+        public static string CopyInput(this ReadOnlySpan<char> input, bool targetSpan, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            if (targetSpan)
+            {
+                spanSuccess = input.TryCopyTo(destination);
+                charsWritten = spanSuccess ? input.Length : 0;
+
+                return null;
+            }
+            else
+            {
+                spanSuccess = false;
+                charsWritten = 0;
+                return input.ToString();
+            }
+        }
+
+        public static string CopyOutput(this ValueStringBuilder vsb, bool targetSpan, Span<char> destination, out int charsWritten, out bool spanSuccess)
+        {
+            if (targetSpan)
+            {
+                spanSuccess = vsb.TryCopyTo(destination, out charsWritten);
+                return null;
+            }
+            else
+            {
+                spanSuccess = false;
+                charsWritten = 0;
+                return vsb.ToString();
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Group.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Group.cs
@@ -6,6 +6,8 @@
 // are captured by a single capturing group after one
 // regular expression match.
 
+using System.Buffers;
+
 namespace System.Text.RegularExpressions
 {
     /// <summary>
@@ -15,13 +17,13 @@ namespace System.Text.RegularExpressions
     /// </summary>
     public class Group : Capture
     {
-        internal static readonly Group s_emptyGroup = new Group(string.Empty, Array.Empty<int>(), 0, string.Empty);
+        internal static readonly Group s_emptyGroup = new Group(default, Array.Empty<int>(), 0, string.Empty);
 
         internal readonly int[] _caps;
         internal int _capcount;
         internal CaptureCollection _capcoll;
 
-        internal Group(string text, int[] caps, int capcount, string name)
+        internal Group(in MemoryOrPinnedSpan<char> text, int[] caps, int capcount, string name)
             : base(text, capcount == 0 ? 0 : caps[(capcount - 1) * 2],
                capcount == 0 ? 0 : caps[(capcount * 2) - 1])
         {
@@ -35,6 +37,9 @@ namespace System.Text.RegularExpressions
         /// </summary>
         public bool Success => _capcount != 0;
 
+        /// <summary>
+        /// The Groups name.
+        /// </summary>
         public string Name { get; }
 
         /// <summary>

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GroupCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GroupCollection.cs
@@ -40,9 +40,9 @@ namespace System.Text.RegularExpressions
 
         public Group this[int groupnum] => GetGroup(groupnum);
 
-        public Group this[string groupname] => _match._regex == null ?
+        public Group this[string groupname] => _match.Regex == null ?
             Group.s_emptyGroup :
-            GetGroup(_match._regex.GroupNumberFromName(groupname));
+            GetGroup(_match.Regex.GroupNumberFromName(groupname));
 
         /// <summary>
         /// Provides an enumerator in the same order as Item[].
@@ -83,7 +83,7 @@ namespace System.Text.RegularExpressions
                 _groups = new Group[_match._matchcount.Length - 1];
                 for (int i = 0; i < _groups.Length; i++)
                 {
-                    string groupname = _match._regex.GroupNameFromNumber(i + 1);
+                    string groupname = _match.Regex.GroupNameFromNumber(i + 1);
                     _groups[i] = new Group(_match.Text, _match._matches[i + 1], _match._matchcount[i + 1], groupname);
                 }
             }
@@ -224,7 +224,7 @@ namespace System.Text.RegularExpressions
 
         public bool ContainsKey(string key)
         {
-            return _match._regex.GroupNumberFromName(key) >= 0;
+            return _match.Regex.GroupNumberFromName(key) >= 0;
         }
 
         public IEnumerable<string> Keys

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
@@ -5,6 +5,7 @@
 // The MatchCollection lists the successful matches that
 // result when searching a string for a regular expression.
 
+using System.Buffers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -27,13 +28,13 @@ namespace System.Text.RegularExpressions
         private readonly Regex _regex;
         private readonly List<Match> _matches;
         private bool _done;
-        private readonly string _input;
+        private readonly MemoryOrPinnedSpan<char> _input;
         private readonly int _beginning;
         private readonly int _length;
         private int _startat;
         private int _prevlen;
 
-        internal MatchCollection(Regex regex, string input, int beginning, int length, int startat)
+        internal MatchCollection(Regex regex, in MemoryOrPinnedSpan<char> input, int beginning, int length, int startat)
         {
             if (startat < 0 || startat > input.Length)
                 throw new ArgumentOutOfRangeException(nameof(startat), SR.BeginIndexNotNegative);
@@ -102,7 +103,7 @@ namespace System.Text.RegularExpressions
 
             do
             {
-                match = _regex.Run(false, _prevlen, _input, _beginning, _length, _startat);
+                match = _regex.Run(false, _prevlen, _input, ReadOnlySpan<char>.Empty, _beginning, _length, _startat);
 
                 if (!match.Success)
                 {
@@ -113,7 +114,7 @@ namespace System.Text.RegularExpressions
                 _matches.Add(match);
 
                 _prevlen = match.Length;
-                _startat = match._textpos;
+                _startat = match.TextPos;
             } while (_matches.Count <= i);
 
             return match;

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -92,7 +92,7 @@ namespace System.Text.RegularExpressions
                 // it wasn't in the cache, so we'll add a new one
                 if (entry == null && isToAdd && s_cacheSize != 0) // check cache size again in case it changed
                 {
-                    entry = new CachedCodeEntry(key, capnames, capslist, _code, caps, capsize, _runnerref, _replref);
+                    entry = new CachedCodeEntry(key, capnames, capslist, _code, caps, capsize, _runnerref, ReplRef);
                     // put first in linked list:
                     if (s_cacheFirst != null)
                     {

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Collections.Generic;
 
 namespace System.Text.RegularExpressions
@@ -30,6 +31,11 @@ namespace System.Text.RegularExpressions
             return new Regex(pattern, options, matchTimeout, true).Split(input);
         }
 
+        public static SplitEnumerator Split(ReadOnlySpan<char> input, string pattern, RegexOptions options = RegexOptions.None, TimeSpan? matchTimeout = null)
+        {
+            return new Regex(pattern, options, matchTimeout ?? s_defaultMatchTimeout, true).Split(input);
+        }
+
         /// <summary>
         /// Splits the <paramref name="input"/> string at the position defined by a
         /// previous pattern.
@@ -39,7 +45,7 @@ namespace System.Text.RegularExpressions
             if (input == null)
                 throw new ArgumentNullException(nameof(input));
 
-            return Split(input, 0, UseOptionR() ? input.Length : 0);
+            return SplitImpl(input, 0, UseOptionR() ? input.Length : 0);
         }
 
         /// <summary>
@@ -51,7 +57,15 @@ namespace System.Text.RegularExpressions
             if (input == null)
                 throw new ArgumentNullException(nameof(input));
 
-            return Split(this, input, count, UseOptionR() ? input.Length : 0);
+            return SplitImpl(input, count, UseOptionR() ? input.Length : 0);
+        }
+
+        public SplitEnumerator Split(ReadOnlySpan<char> input, int count = 0)
+        {
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count), SR.CountTooSmall);
+
+            return new SplitEnumerator(this, input, count);
         }
 
         /// <summary>
@@ -62,44 +76,37 @@ namespace System.Text.RegularExpressions
             if (input == null)
                 throw new ArgumentNullException(nameof(input));
 
-            return Split(this, input, count, startat);
+            return SplitImpl(input, count, startat);
         }
 
         /// <summary>
         /// Does a split. In the right-to-left case we reorder the
         /// array to be forwards.
         /// </summary>
-        private static string[] Split(Regex regex, string input, int count, int startat)
+        private string[] SplitImpl(string input, int count, int startat)
         {
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.CountTooSmall);
             if (startat < 0 || startat > input.Length)
                 throw new ArgumentOutOfRangeException(nameof(startat), SR.BeginIndexNotNegative);
 
-            string[] result;
-
             if (count == 1)
             {
-                result = new string[1];
-                result[0] = input;
-                return result;
+                return new string[1] { input };
             }
 
             count -= 1;
-
-            Match match = regex.Match(input, startat);
+            Match match = Match(input, startat);
 
             if (!match.Success)
             {
-                result = new string[1];
-                result[0] = input;
-                return result;
+                return new string[1] { input };
             }
             else
             {
-                List<string> al = new List<string>();
+                var al = new List<string>();
 
-                if (!regex.RightToLeft)
+                if (!RightToLeft)
                 {
                     int prevat = 0;
 
@@ -154,11 +161,146 @@ namespace System.Text.RegularExpressions
                     }
 
                     al.Add(input.Substring(0, prevat));
-
-                    al.Reverse(0, al.Count);
+                    al.Reverse();
                 }
 
                 return al.ToArray();
+            }
+        }
+
+        public ref struct SplitEnumerator
+        {
+            private readonly Regex _regex;
+            private ReadOnlySpan<char> _input;
+            private readonly int _count;
+            private int _index;
+            private Match _match;
+            private int _inputIndex;
+            private int _groupIndex;
+
+            internal SplitEnumerator(Regex regex, ReadOnlySpan<char> input, int count)
+            {
+                _regex = regex;
+                _input = input;
+                _count = count;
+                _index = 0;
+                _match = null;
+                _inputIndex = _regex.RightToLeft ? input.Length : 0;
+                _groupIndex = 1;
+                Current = null;
+            }
+
+            /// <summary>
+            /// Gets the element at the current position of the enumerator.
+            /// </summary>
+            public ReadOnlySpan<char> Current { get; private set; }
+
+            public SplitEnumerator GetEnumerator() => this;
+
+            // Count <0 => throw in public API.
+            // Count 0 => no boundary, iterate over all matches.
+            // Count 1 => return whole string.
+            // Count n => return n splits for n matches.
+            public bool MoveNext()
+            {
+                // Exit if count limit is reached (count 0 means no limit) or
+                // if the exist condition (index negative) is set.
+                if ((_index >= _count && _count != 0) || _index < 0)
+                {
+                    return false;
+                }
+
+                // If count is 1 and we are in the first iteration we just return the input text.
+                if (_index == 0 && _count == 1)
+                {
+                    Current = _input;
+                    _index++;
+                    return true;
+                }
+
+                // If last iteration yield the remainder.
+                if (_index + 1 == _count)
+                {
+                    if (!_regex.RightToLeft)
+                    {
+                        Current = _input.Slice(_inputIndex, _input.Length - _inputIndex);
+                    }
+                    else
+                    {
+                        Current = _input.Slice(0, _inputIndex);
+                    }
+
+                    _index++;
+                    return true;
+                }
+
+                if (_match == null)
+                {
+                    // First iteration, set the match with RTL considered.
+                    _match = _regex.Run(false, -1, default, _input, 0, _input.Length, _regex.RightToLeft ? _input.Length : 0);
+                }
+                else
+                {
+                    // Before going to the next match, yield all except the first (which is the match itself) 
+                    // capture groups in the current match.
+                    while (_groupIndex < _match.Groups.Count)
+                    {
+                        if (_match.IsMatched(_groupIndex))
+                        {
+                            // We don't access the match Value property directly as we didn't set it.
+                            Group group = _match.Groups[_groupIndex];
+                            Current = _input.Slice(group.Index, group.Length);
+
+                            _groupIndex++;
+                            return true;
+                        }
+
+                        _groupIndex++;
+                    }
+
+                    // Evaluate next match and reset capture group index.
+                    _match = _match.NextMatch(_input);
+                    _groupIndex = 1;
+                }
+
+                // If match evaluation fails, exit.
+                if (!_match.Success)
+                {
+                    // If in first iteration, return the input text.
+                    if (_index == 0)
+                    {
+                        Current = _input;
+                    }
+                    // Otherwise return the remainder of the last match index to the end of text (RTL or LTR).
+                    else if (!_regex.RightToLeft)
+                    {
+                        Current = _input.Slice(_inputIndex, _input.Length - _inputIndex);
+                    }
+                    else
+                    {
+                        Current = _input.Slice(0, _inputIndex);
+                    }
+
+                    // Set exit condition.
+                    _index = -1;
+                    return true;
+                }
+
+                // Match evaulation is successful, yield the text between the last match and the current match
+                // and continue iteration.
+                if (!_regex.RightToLeft)
+                {
+                    Current = _input.Slice(_inputIndex, _match.Index - _inputIndex);
+                    _inputIndex = _match.Index + _match.Length;
+                }
+                else
+                {
+                    Current = _input.Slice(_match.Index + _match.Length, _inputIndex - _match.Index - _match.Length);
+                    _inputIndex = _match.Index;
+                }
+
+                _index++;
+                return true;
             }
         }
     }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -5,6 +5,7 @@
 // The Regex class represents a single compiled instance of a regular
 // expression.
 
+using System.Buffers;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -34,10 +35,9 @@ namespace System.Text.RegularExpressions
         protected internal string[] capslist;                // if captures are sparse or named captures are used, this is the sorted list of names
         protected internal int capsize;                      // the size of the capture array
         
-        internal ExclusiveReference _runnerref;              // cached runner
-        internal WeakReference<RegexReplacement> _replref; // cached parsed replacement pattern
-        internal RegexCode _code;                            // if interpreted, this is the code for RegexInterpreter
-        internal bool _refsInitialized = false;
+        private ExclusiveReference _runnerref;               // cached runner
+        private RegexCode _code;                             // if interpreted, this is the code for RegexInterpreter
+        private bool _refsInitialized = false;
 
         protected Regex()
         {
@@ -149,7 +149,7 @@ namespace System.Text.RegularExpressions
 
                 // Cache runner and replacement
                 _runnerref = cached.Runnerref;
-                _replref = cached.ReplRef;
+                ReplRef = cached.ReplRef;
                 _refsInitialized = true;
             }
 
@@ -201,6 +201,11 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>
+        /// Cached parsed replacement pattern.
+        /// </summary>
+        internal WeakReference<RegexReplacement> ReplRef { get; private set; } 
+
 #if FEATURE_COMPILED
         /// <summary>
         /// This method is here for perf reasons: if the call to RegexCompiler is NOT in the 
@@ -245,7 +250,24 @@ namespace System.Text.RegularExpressions
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
 
-            return RegexParser.Escape(str);
+            return RegexParser.Escape(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
+        }
+
+        /// <summary>
+        /// Escapes a minimal set of metacharacters (\, *, +, ?, |, {, [, (, ), ^, $, ., #, and
+        /// whitespace) by replacing them with their \ codes. This converts a string so that
+        /// it can be used as a constant within a regular expression safely. (Note that the
+        /// reason # and whitespace must be escaped is so the string can be used safely
+        /// within an expression parsed with x mode. If future Regex features add
+        /// additional metacharacters, developers should depend on Escape to escape those
+        /// characters as well.)
+        /// </summary>
+        /// <returns>Returns the amount of chars written into the output Span.</returns>
+        public static bool TryEscape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten)
+        {
+            RegexParser.Escape(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
+
+            return spanSuccess;
         }
 
         /// <summary>
@@ -256,7 +278,17 @@ namespace System.Text.RegularExpressions
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
 
-            return RegexParser.Unescape(str);
+            return RegexParser.Unescape(targetSpan: false, str.AsSpan(), Span<char>.Empty, out _, out _);
+        }
+
+        /// <summary>
+        /// Unescapes any escaped characters in the input text.
+        /// </summary>
+        public static bool TryUnescape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten)
+        {
+            RegexParser.Unescape(targetSpan: true, str, destination, out charsWritten, out bool spanSuccess);
+
+            return spanSuccess;
         }
 
         /// <summary>
@@ -432,44 +464,77 @@ namespace System.Text.RegularExpressions
 
             _refsInitialized = true;
             _runnerref = new ExclusiveReference();
-            _replref = new WeakReference<RegexReplacement>(null);
+            ReplRef = new WeakReference<RegexReplacement>(null);
         }
 
         /// <summary>
-        /// Internal worker called by all the public APIs
+        /// Internal worker called by all the public APIs. Accepts both a Memory and Span. Usually one of these 
+        /// two is empty depending on the scenario. Unidirectional APIs that are unidirectional like IsMatch, 
+        /// Replace (with no MatchEvaluator) and Split should pass the input text as a Span (with an empty Memory).
+        /// Bidirectional APIs where the input needs to be passed around i.e. Match and Matches, should pass the input
+        /// text as a Memory (with an empty Span). Replace with an MatchEvaluator is special as it's unidirectional but
+        /// the evaluator can access the Match object which is the internal state and contains the input text.
         /// </summary>
-        /// <returns></returns>
-        internal Match Run(bool quick, int prevlen, string input, int beginning, int length, int startat)
+        internal Match Run(bool quick, int prevlen, in MemoryOrPinnedSpan<char> mem, ReadOnlySpan<char> span, int beginning, int length, int startat)
         {
+            // If a non empty Span is passed, use it and avoid Span creation from Memory.
+            ReadOnlySpan<char> input = !span.IsEmpty ? span : mem.Span;
+
             if (startat < 0 || startat > input.Length)
                 throw new ArgumentOutOfRangeException(nameof(startat), SR.BeginIndexNotNegative);
-
             if (length < 0 || length > input.Length)
                 throw new ArgumentOutOfRangeException(nameof(length), SR.LengthNotNegative);
 
-            // There may be a cached runner; grab ownership of it if we can.
-            RegexRunner runner = _runnerref.Get();
-
-            // Create a RegexRunner instance if we need to
-            if (runner == null)
-            {
-                // Use the compiled RegexRunner factory if the code was compiled to MSIL
-                if (factory != null)
-                    runner = factory.CreateInstance();
-                else
-                    runner = new RegexInterpreter(_code, UseOptionInvariant() ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
-            }
-
             Match match;
-            try
+            object obj = _runnerref.Get();
+
+            // Interpreted
+            if (factory == null)
             {
-                // Do the scan starting at the requested position
-                match = runner.Scan(this, input, beginning, beginning + length, startat, prevlen, quick, internalMatchTimeout);
+                RegexInterpreter interpretedRunner;
+                if (obj is RegexInterpreter interpreted)
+                    interpretedRunner = interpreted;
+                else
+                {
+                    if (obj != null)
+                        _runnerref.Release(obj);
+
+                    interpretedRunner = new RegexInterpreter(_code, UseOptionInvariant() ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
+                }
+
+                try
+                {
+                    match = interpretedRunner.Scan(this, mem, input, beginning, beginning + length, startat, prevlen, quick, internalMatchTimeout);
+                }
+                finally
+                {
+                    _runnerref.Release(interpretedRunner);
+                }
             }
-            finally
+            // Compiled
+            else
             {
-                // Release or fill the cache slot
-                _runnerref.Release(runner);
+
+                RegexRunner compiledRunner;
+                if (obj is RegexRunner compiled)
+                    compiledRunner = compiled;
+                else
+                {
+                    if (obj != null)
+                        _runnerref.Release(obj);
+
+                    compiledRunner = factory.CreateInstance();
+                }
+
+                try
+                {
+                    // Currently we don't support Span/Memory in compiled runners.
+                    match = compiledRunner.Scan(this, input.ToString(), beginning, beginning + length, startat, prevlen, quick, internalMatchTimeout);
+                }
+                finally
+                {
+                    _runnerref.Release(compiledRunner);
+                }
             }
 
 #if DEBUG

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefix.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefix.cs
@@ -6,16 +6,16 @@ namespace System.Text.RegularExpressions
 {
     internal readonly struct RegexPrefix
     {
-        internal RegexPrefix(string prefix, bool ci)
+        public RegexPrefix(string prefix, bool ci)
         {
             Prefix = prefix;
             CaseInsensitive = ci;
         }
 
-        internal bool CaseInsensitive { get; }
+        public bool CaseInsensitive { get; }
 
-        internal static RegexPrefix Empty { get; } = new RegexPrefix(string.Empty, false);
+        public static RegexPrefix Empty { get; } = new RegexPrefix(string.Empty, false);
 
-        internal string Prefix { get; }
+        public string Prefix { get; }
     }
 }

--- a/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -14,6 +14,7 @@
 // methods to push new subpattern match results into (or remove
 // backtracked results from) the Match instance.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 
@@ -275,13 +276,13 @@ namespace System.Text.RegularExpressions
             if (runmatch == null)
             {
                 if (runregex.caps != null)
-                    runmatch = new MatchSparse(runregex, runregex.caps, runregex.capsize, runtext, runtextbeg, runtextend - runtextbeg, runtextstart);
+                    runmatch = new MatchSparse(runregex, runregex.caps, runregex.capsize, new MemoryOrPinnedSpan<char>(runtext.AsMemory()), runtextbeg, runtextend - runtextbeg, runtextstart);
                 else
-                    runmatch = new Match(runregex, runregex.capsize, runtext, runtextbeg, runtextend - runtextbeg, runtextstart);
+                    runmatch = new Match(runregex, runregex.capsize, new MemoryOrPinnedSpan<char>(runtext.AsMemory()), runtextbeg, runtextend - runtextbeg, runtextstart);
             }
             else
             {
-                runmatch.Reset(runregex, runtext, runtextbeg, runtextend, runtextstart);
+                runmatch.Reset(runregex, new MemoryOrPinnedSpan<char>(runtext.AsMemory()), runtextbeg, runtextend, runtextstart);
             }
 
             // note we test runcrawl, because it is the last one to be allocated

--- a/src/System.Text.RegularExpressions/tests/Regex.EscapeUnescape.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.EscapeUnescape.Tests.cs
@@ -16,7 +16,13 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("", "")]
         public static void Escape(string str, string expected)
         {
+            // Use Escape(string)
             Assert.Equal(expected, Regex.Escape(str));
+
+            // Use Escape(ReadOnlySpan, Span)
+            Span<char> output = stackalloc char[255];
+            bool success = Regex.TryEscape(str.AsSpan(), output, out int charsWritten);
+            SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
         }
 
         [Fact]
@@ -35,6 +41,11 @@ namespace System.Text.RegularExpressions.Tests
         public void Unescape(string str, string expected)
         {
             Assert.Equal(expected, Regex.Unescape(str));
+
+            // Use Escape(ReadOnlySpan, Span)
+            Span<char> output = stackalloc char[255];
+            bool success = Regex.TryUnescape(str.AsSpan(), output, out int charsWritten);
+            SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
         }
 
         [Fact]

--- a/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Linq;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -311,30 +310,47 @@ namespace System.Text.RegularExpressions.Tests
             {
                 if (isDefaultStart && isDefaultCount)
                 {
-                    // Use Match(string) or Match(string, string)
+                    // Use Match(string) & Match(Memory)
                     VerifyMatch(new Regex(pattern).Match(input), expectedSuccess, expectedValue);
-                    VerifyMatch(Regex.Match(input, pattern), expectedSuccess, expectedValue);
+                    VerifyMatch(new Regex(pattern).Match(input.AsMemory()), expectedSuccess, expectedValue);
 
+                    // Match(string, string) & Match(Memory, string)
+                    VerifyMatch(Regex.Match(input, pattern), expectedSuccess, expectedValue);
+                    VerifyMatch(Regex.Match(input.AsMemory(), pattern), expectedSuccess, expectedValue);
+
+                    // Use IsMatch(string) & IsMatch(Span)
                     Assert.Equal(expectedSuccess, new Regex(pattern).IsMatch(input));
+                    Assert.Equal(expectedSuccess, new Regex(pattern).IsMatch(input.AsSpan()));
+
+                    // Use IsMatch(string, string) & IsMatch(Span, string)
                     Assert.Equal(expectedSuccess, Regex.IsMatch(input, pattern));
+                    Assert.Equal(expectedSuccess, Regex.IsMatch(input.AsSpan(), pattern));
                 }
                 if (beginning + length == input.Length)
                 {
                     // Use Match(string, int)
                     VerifyMatch(new Regex(pattern).Match(input, beginning), expectedSuccess, expectedValue);
 
+                    // Use IsMatch(string, int)
                     Assert.Equal(expectedSuccess, new Regex(pattern).IsMatch(input, beginning));
                 }
-                // Use Match(string, int, int)
+                // Use Match(string, int, int) & Match(Memory, int, int)
+                VerifyMatch(new Regex(pattern).Match(input, beginning, length), expectedSuccess, expectedValue);
                 VerifyMatch(new Regex(pattern).Match(input, beginning, length), expectedSuccess, expectedValue);
             }
             if (isDefaultStart && isDefaultCount)
             {
-                // Use Match(string) or Match(string, string, RegexOptions)
+                // Use Match(string) & Match(Memory)
                 VerifyMatch(new Regex(pattern, options).Match(input), expectedSuccess, expectedValue);
-                VerifyMatch(Regex.Match(input, pattern, options), expectedSuccess, expectedValue);
+                VerifyMatch(new Regex(pattern, options).Match(input.AsMemory()), expectedSuccess, expectedValue);
 
+                // Use Match(string, string, RegexOptions) & Match(Memory, string, RegexOptions)
+                VerifyMatch(Regex.Match(input, pattern, options), expectedSuccess, expectedValue);
+                VerifyMatch(Regex.Match(input.AsMemory(), pattern, options), expectedSuccess, expectedValue);
+
+                // Use IsMatch(string, string, RegexOptions) & IsMatch(Span, string, RegexOptions)
                 Assert.Equal(expectedSuccess, Regex.IsMatch(input, pattern, options));
+                Assert.Equal(expectedSuccess, Regex.IsMatch(input.AsSpan(), pattern, options));
             }
             if (beginning + length == input.Length && (options & RegexOptions.RightToLeft) == 0)
             {
@@ -349,11 +365,13 @@ namespace System.Text.RegularExpressions.Tests
         {
             Assert.Equal(expectedSuccess, match.Success);
             Assert.Equal(expectedValue, match.Value);
+            Assert.Equal(expectedValue, match.ValueSpan.ToString());
 
             // Groups can never be empty
             Assert.True(match.Groups.Count >= 1);
             Assert.Equal(expectedSuccess, match.Groups[0].Success);
             Assert.Equal(expectedValue, match.Groups[0].Value);
+            Assert.Equal(expectedValue, match.Groups[0].ValueSpan.ToString());
         }
 
         [Fact]
@@ -668,18 +686,28 @@ namespace System.Text.RegularExpressions.Tests
             {
                 if (isDefaultStart && isDefaultCount)
                 {
-                    // Use Match(string) or Match(string, string)
+                    // Use Match(string) & Match(Memory)
                     VerifyMatch(new Regex(pattern).Match(input), true, expected);
-                    VerifyMatch(Regex.Match(input, pattern), true, expected);
+                    VerifyMatch(new Regex(pattern).Match(input.AsMemory()), true, expected);
 
+                    // Use Match(string, string) & Match(Memory, string)
+                    VerifyMatch(Regex.Match(input, pattern), true, expected);
+                    VerifyMatch(Regex.Match(input.AsMemory(), pattern), true, expected);
+
+                    // Use IsMatch(string) & IsMatch(Span)
                     Assert.True(new Regex(pattern).IsMatch(input));
+                    Assert.True(new Regex(pattern).IsMatch(input.AsSpan()));
+
+                    // Use IsMatch(string, string) & IsMatch(Span, string)
                     Assert.True(Regex.IsMatch(input, pattern));
+                    Assert.True(Regex.IsMatch(input.AsSpan(), pattern));
                 }
                 if (beginning + length == input.Length)
                 {
                     // Use Match(string, int)
                     VerifyMatch(new Regex(pattern).Match(input, beginning), true, expected);
 
+                    // Use IsMatch(string, int)
                     Assert.True(new Regex(pattern).IsMatch(input, beginning));
                 }
                 else
@@ -690,11 +718,17 @@ namespace System.Text.RegularExpressions.Tests
             }
             if (isDefaultStart && isDefaultCount)
             {
-                // Use Match(string) or Match(string, string, RegexOptions)
+                // Use Match(string) & Match(Memory)
                 VerifyMatch(new Regex(pattern, options).Match(input), true, expected);
-                VerifyMatch(Regex.Match(input, pattern, options), true, expected);
+                VerifyMatch(new Regex(pattern, options).Match(input.AsMemory()), true, expected);
 
+                // Use Match(string, string, RegexOptions) & Match(Memory, string, RegexOptions)
+                VerifyMatch(Regex.Match(input, pattern, options), true, expected);
+                VerifyMatch(Regex.Match(input.AsMemory(), pattern, options), true, expected);
+
+                // Use IsMatch(string, string, RegexOptions) & IsMatch(Span, string, RegexOptions)
                 Assert.True(Regex.IsMatch(input, pattern, options));
+                Assert.True(Regex.IsMatch(input.AsSpan(), pattern, options));
             }
             if (beginning + length == input.Length)
             {
@@ -713,11 +747,13 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(expectedSuccess, match.Success);
 
             Assert.Equal(expected[0].Value, match.Value);
+            Assert.Equal(expected[0].Value, match.ValueSpan.ToString());
             Assert.Equal(expected[0].Index, match.Index);
             Assert.Equal(expected[0].Length, match.Length);
 
             Assert.Equal(1, match.Captures.Count);
             Assert.Equal(expected[0].Value, match.Captures[0].Value);
+            Assert.Equal(expected[0].Value, match.Captures[0].ValueSpan.ToString());
             Assert.Equal(expected[0].Index, match.Captures[0].Index);
             Assert.Equal(expected[0].Length, match.Captures[0].Length);
 
@@ -727,6 +763,7 @@ namespace System.Text.RegularExpressions.Tests
                 Assert.Equal(expectedSuccess, match.Groups[i].Success);
 
                 Assert.Equal(expected[i].Value, match.Groups[i].Value);
+                Assert.Equal(expected[i].Value, match.Groups[i].ValueSpan.ToString());
                 Assert.Equal(expected[i].Index, match.Groups[i].Index);
                 Assert.Equal(expected[i].Length, match.Groups[i].Length);
 
@@ -734,6 +771,7 @@ namespace System.Text.RegularExpressions.Tests
                 for (int j = 0; j < match.Groups[i].Captures.Count; j++)
                 {
                     Assert.Equal(expected[i].Captures[j].Value, match.Groups[i].Captures[j].Value);
+                    Assert.Equal(expected[i].Captures[j].Value, match.Groups[i].Captures[j].ValueSpan.ToString());
                     Assert.Equal(expected[i].Captures[j].Index, match.Groups[i].Captures[j].Index);
                     Assert.Equal(expected[i].Captures[j].Length, match.Groups[i].Captures[j].Length);
                 }
@@ -748,7 +786,13 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData("abc", "abc", "abc", "abc")]
         public void Result(string pattern, string input, string replacement, string expected)
         {
+            // Use Match.Result(string)
             Assert.Equal(expected, new Regex(pattern).Match(input).Result(replacement));
+
+            // Use Match.Result(string, Span)
+            Span<char> output = stackalloc char[255];
+            bool success = new Regex(pattern).Match(input.AsMemory()).TryResult(replacement, output, out int charsWritten);
+            SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
         }
 
         [Fact]
@@ -756,8 +800,10 @@ namespace System.Text.RegularExpressions.Tests
         {
             Match match = Regex.Match("foo", "foo");
             AssertExtensions.Throws<ArgumentNullException>("replacement", () => match.Result(null));
+            AssertExtensions.Throws<ArgumentNullException>("replacement", () => match.TryResult(null, default, out _));
 
             Assert.Throws<NotSupportedException>(() => RegularExpressions.Match.Empty.Result("any"));
+            Assert.Throws<NotSupportedException>(() => RegularExpressions.Match.Empty.TryResult("any", default, out _));
         }
 
         [Fact]
@@ -766,6 +812,7 @@ namespace System.Text.RegularExpressions.Tests
             RemoteInvoke(() =>
             {
                 CultureInfo.CurrentCulture = new CultureInfo("en-US");
+                Match("\u0131", "\u0049", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
                 Match("\u0131", "\u0049", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
                 Match("\u0131", "\u0069", RegexOptions.IgnoreCase, 0, 1, false, string.Empty);
 
@@ -796,9 +843,15 @@ namespace System.Text.RegularExpressions.Tests
             {
                 // Should not throw out of memory
                 Assert.False(Regex.IsMatch("a", @"a{2147483647,}"));
-                Assert.False(Regex.IsMatch("a", @"a{1000001,}")); // 1 over the cutoff for Boyer-Moore prefix
+                Assert.False(Regex.IsMatch("a".AsSpan(), @"a{2147483647,}"));
 
-                Assert.False(Regex.IsMatch("a", @"a{50000}")); // creates string for Boyer-Moore but not so large that tests fail and start paging
+                // 1 over the cutoff for Boyer-Moore prefix
+                Assert.False(Regex.IsMatch("a", @"a{1000001,}"));
+                Assert.False(Regex.IsMatch("a".AsSpan(), @"a{1000001,}"));
+
+                // creates string for Boyer-Moore but not so large that tests fail and start paging
+                Assert.False(Regex.IsMatch("a", @"a{50000}"));
+                Assert.False(Regex.IsMatch("a".AsSpan(), @"a{50000}"));
             }).Dispose();
         }
 
@@ -808,16 +861,17 @@ namespace System.Text.RegularExpressions.Tests
             // Input is null
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Match(null, "pattern"));
             AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Match(null, "pattern", RegexOptions.None));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Match(null, "pattern", RegexOptions.None, TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Match((string)null, "pattern", RegexOptions.None, TimeSpan.FromSeconds(1)));
 
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match(null));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match(null, 0));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match(null, 0, 0));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match((string)null));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match((string)null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Match((string)null, 0, 0));
 
             // Pattern is null
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null, RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Match("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Match("input".AsMemory(), null, RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             // Start is invalid
             Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").Match("input", -1));
@@ -829,7 +883,7 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => new Regex("pattern").Match("input", 0, -1));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("length", () => new Regex("pattern").Match("input", 0, 6));
         }
-
+        
         [Fact]
         public void IsMatch_Invalid()
         {
@@ -843,8 +897,11 @@ namespace System.Text.RegularExpressions.Tests
 
             // Pattern is null
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input", null));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input".AsSpan(), null));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input", null, RegexOptions.None));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input".AsSpan(), null, RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.IsMatch("input".AsSpan(), null, RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             // Start is invalid
             Assert.Throws<ArgumentOutOfRangeException>(() => new Regex("pattern").IsMatch("input", -1));

--- a/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.MultipleMatches.Tests.cs
@@ -9,42 +9,52 @@ namespace System.Text.RegularExpressions.Tests
 {
     public class RegexMultipleMatchTests
     {
-
         [Fact]
         public void Matches_MultipleCapturingGroups()
+        {
+            // Another example - given by Brad Merril in an article on RegularExpressions
+            Regex regex = new Regex(@"(abra(cad)?)+");
+            string input = "abracadabra1abracadabra2abracadabra3";
+            ValidateMatch(regex.Match(input));
+            ValidateMatch(regex.Match(input.AsMemory()));
+        }
+
+        private static void ValidateMatch(Match match)
         {
             string[] expectedGroupValues = { "abracadabra", "abra", "cad" };
             string[] expectedGroupCaptureValues = { "abracad", "abra" };
 
-            // Another example - given by Brad Merril in an article on RegularExpressions
-            Regex regex = new Regex(@"(abra(cad)?)+");
-            string input = "abracadabra1abracadabra2abracadabra3";
-            Match match = regex.Match(input);
             while (match.Success)
             {
                 string expected = "abracadabra";
                 Assert.Equal(expected, match.Value);
+                Assert.Equal(expected, match.ValueSpan.ToString());
 
                 Assert.Equal(3, match.Groups.Count);
                 for (int i = 0; i < match.Groups.Count; i++)
                 {
                     Assert.Equal(expectedGroupValues[i], match.Groups[i].Value);
+                    Assert.Equal(expectedGroupValues[i], match.Groups[i].ValueSpan.ToString());
                     if (i == 1)
                     {
                         Assert.Equal(2, match.Groups[i].Captures.Count);
                         for (int j = 0; j < match.Groups[i].Captures.Count; j++)
                         {
                             Assert.Equal(expectedGroupCaptureValues[j], match.Groups[i].Captures[j].Value);
+                            Assert.Equal(expectedGroupCaptureValues[j], match.Groups[i].Captures[j].ValueSpan.ToString());
                         }
                     }
                     else if (i == 2)
                     {
                         Assert.Equal(1, match.Groups[i].Captures.Count);
                         Assert.Equal("cad", match.Groups[i].Captures[0].Value);
+                        Assert.Equal("cad", match.Groups[i].Captures[0].ValueSpan.ToString());
                     }
                 }
                 Assert.Equal(1, match.Captures.Count);
                 Assert.Equal("abracadabra", match.Captures[0].Value);
+                Assert.Equal("abracadabra", match.Captures[0].ValueSpan.ToString());
+
                 match = match.NextMatch();
             }
         }
@@ -149,19 +159,41 @@ namespace System.Text.RegularExpressions.Tests
             if (options == RegexOptions.None)
             {
                 Regex regexBasic = new Regex(pattern);
-                VerifyMatches(regexBasic.Matches(input), expected);
-                VerifyMatches(regexBasic.Match(input), expected);
 
+                // Use Matches(string) & Matches(Memory)
+                VerifyMatches(regexBasic.Matches(input), expected);
+                VerifyMatches(regexBasic.Matches(input.AsMemory()), expected);
+
+                // Use Match(string) & Match(Memory)
+                VerifyMatches(regexBasic.Match(input), expected);
+                VerifyMatches(regexBasic.Match(input.AsMemory()), expected);
+
+                // Use Matches(string, string) & Matches(Memory, string)
                 VerifyMatches(Regex.Matches(input, pattern), expected);
+                VerifyMatches(Regex.Matches(input.AsMemory(), pattern), expected);
+
+                // Use Match(string, string) & Match(Memory, string)
                 VerifyMatches(Regex.Match(input, pattern), expected);
+                VerifyMatches(Regex.Match(input.AsMemory(), pattern), expected);
             }
 
             Regex regexAdvanced = new Regex(pattern, options);
-            VerifyMatches(regexAdvanced.Matches(input), expected);
-            VerifyMatches(regexAdvanced.Match(input), expected);
 
+            // Use Matches(string) & Matches(Memory)
+            VerifyMatches(regexAdvanced.Matches(input), expected);
+            VerifyMatches(regexAdvanced.Matches(input.AsMemory()), expected);
+
+            // Use Match(string) & Match(Memory)
+            VerifyMatches(regexAdvanced.Match(input), expected);
+            VerifyMatches(regexAdvanced.Match(input.AsMemory()), expected);
+
+            // Use Matches(string, string, RegexOptions) & (Memory, string, RegexOptions)
             VerifyMatches(Regex.Matches(input, pattern, options), expected);
+            VerifyMatches(Regex.Matches(input.AsMemory(), pattern, options), expected);
+
+            // Use Match(string, string, RegexOptions) & Match(Memory, pattern, RegexOptions)
             VerifyMatches(Regex.Match(input, pattern, options), expected);
+            VerifyMatches(Regex.Match(input.AsMemory(), pattern, options), expected);
         }
 
         public static void VerifyMatches(Match match, CaptureData[] expected)
@@ -185,15 +217,18 @@ namespace System.Text.RegularExpressions.Tests
         {
             Assert.True(match.Success);
             Assert.Equal(expected.Value, match.Value);
+            Assert.Equal(expected.Value, match.ValueSpan.ToString());
             Assert.Equal(expected.Index, match.Index);
             Assert.Equal(expected.Length, match.Length);
 
             Assert.Equal(expected.Value, match.Groups[0].Value);
+            Assert.Equal(expected.Value, match.Groups[0].ValueSpan.ToString());
             Assert.Equal(expected.Index, match.Groups[0].Index);
             Assert.Equal(expected.Length, match.Groups[0].Length);
 
             Assert.Equal(1, match.Captures.Count);
             Assert.Equal(expected.Value, match.Captures[0].Value);
+            Assert.Equal(expected.Value, match.Captures[0].ValueSpan.ToString());
             Assert.Equal(expected.Index, match.Captures[0].Index);
             Assert.Equal(expected.Length, match.Captures[0].Length);
         }
@@ -202,27 +237,31 @@ namespace System.Text.RegularExpressions.Tests
         public void Matches_Invalid()
         {
             // Input is null
-            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Matches(null, "pattern"));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Matches(null, "pattern", RegexOptions.None));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Matches(null, "pattern", RegexOptions.None, TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Matches((string)null, "pattern"));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Matches((string)null, "pattern", RegexOptions.None));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => Regex.Matches((string)null, "pattern", RegexOptions.None, TimeSpan.FromSeconds(1)));
 
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Matches(null));
-            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Matches(null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Matches((string)null));
+            AssertExtensions.Throws<ArgumentNullException>("input", () => new Regex("pattern").Matches((string)null, 0));
 
             // Pattern is null
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Matches("input", null));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Matches("input", null, RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Matches("input", null, RegexOptions.None, TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Matches("input".AsMemory(), null, RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             // Options are invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)(-1), TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input".AsMemory(), "pattern", (RegexOptions)(-1), TimeSpan.FromSeconds(1)));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x400));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input", "pattern", (RegexOptions)0x400, TimeSpan.FromSeconds(1)));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("options", () => Regex.Matches("input".AsMemory(), "pattern", (RegexOptions)0x400, TimeSpan.FromSeconds(1)));
 
             // MatchTimeout is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.Matches("input", "pattern", RegexOptions.None, TimeSpan.Zero));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.Matches("input", "pattern", RegexOptions.None, TimeSpan.Zero));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("matchTimeout", () => Regex.Matches("input".AsMemory(), "pattern", RegexOptions.None, TimeSpan.Zero));
 
             // Start is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startat", () => new Regex("pattern").Matches("input", -1));

--- a/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Replace.Tests.cs
@@ -115,32 +115,52 @@ namespace System.Text.RegularExpressions.Tests
         {
             bool isDefaultStart = RegexHelpers.IsDefaultStart(input, options, start);
             bool isDefaultCount = RegexHelpers.IsDefaultCount(input, options, count);
+            Span<char> output = stackalloc char[1000]; // largest input is 1000 chars long.
+            int charsWritten = 0;
+            bool success = false;
+
             if (options == RegexOptions.None)
             {
                 if (isDefaultStart && isDefaultCount)
                 {
-                    // Use Replace(string, string) or Replace(string, string, string)
+                    // Use Replace(string, string) & TryReplace(Span, string, Span, out int)
                     Assert.Equal(expected, new Regex(pattern).Replace(input, replacement));
+                    success = new Regex(pattern).TryReplace(input.AsSpan(), replacement, output, out charsWritten);
+                    SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
+
+                    // Use Replace(string, string, string) & TryReplace(Span, string, string, Span, out int)
                     Assert.Equal(expected, Regex.Replace(input, pattern, replacement));
+                    success = Regex.TryReplace(input.AsSpan(), pattern, replacement, output, out charsWritten);
+                    SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
                 }
                 if (isDefaultStart)
                 {
-                    // Use Replace(string, string, string, int)
+                    // Use Replace(string, string, int) & TryReplace(Span, string, Span, out int, int)
                     Assert.Equal(expected, new Regex(pattern).Replace(input, replacement, count));
+                    success = new Regex(pattern).TryReplace(input.AsSpan(), replacement, output, out charsWritten, count);
+                    SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
                 }
                 // Use Replace(string, string, int, int)
                 Assert.Equal(expected, new Regex(pattern).Replace(input, replacement, count, start));
             }
             if (isDefaultStart && isDefaultCount)
             {
-                // Use Replace(string, string) or Replace(string, string, string, RegexOptions)
+                // Use Replace(string, string) & TryReplace(Span, string, Span, out int)
                 Assert.Equal(expected, new Regex(pattern, options).Replace(input, replacement));
+                success = new Regex(pattern, options).TryReplace(input.AsSpan(), replacement, output, out charsWritten);
+                SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
+
+                // Use Replace(string, string, string, RegexOptions) & TryReplace(Span, string, string, Span, out int, RegexOptions)
                 Assert.Equal(expected, Regex.Replace(input, pattern, replacement, options));
+                success = Regex.TryReplace(input.AsSpan(), pattern, replacement, output, out charsWritten, options);
+                SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
             }
             if (isDefaultStart)
             {
-                // Use Replace(string, string, string, int)
+                // Use Replace(string, string, string, int) & Replace(Span, string, Span, out int, string)
                 Assert.Equal(expected, new Regex(pattern, options).Replace(input, replacement, count));
+                success = new Regex(pattern, options).TryReplace(input.AsSpan(), replacement, output, out charsWritten, count);
+                SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
             }
             // Use Replace(string, string, int, int)
             Assert.Equal(expected, new Regex(pattern, options).Replace(input, replacement, count, start));
@@ -185,32 +205,53 @@ namespace System.Text.RegularExpressions.Tests
         {
             bool isDefaultStart = RegexHelpers.IsDefaultStart(input, options, start);
             bool isDefaultCount = RegexHelpers.IsDefaultCount(input, options, count);
+            Span<char> output = stackalloc char[255];
+            int charsWritten = 0;
+            bool success = false;
+
             if (options == RegexOptions.None)
             {
                 if (isDefaultStart && isDefaultCount)
                 {
-                    // Use Replace(string, MatchEvaluator) or Replace(string, string, MatchEvaluator)
+                    // Use Replace(string, MatchEvaluator) & TryReplace(Span, MatchEvaluator, Span, out int) 
                     Assert.Equal(expected, new Regex(pattern).Replace(input, evaluator));
+                    success = new Regex(pattern).TryReplace(input.AsSpan(), evaluator, output, out charsWritten);
+                    SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
+
+                    // Use Replace(string, string, MatchEvaluator) & TryReplace(Span, string, MatchEvaluator, Span, out int)
                     Assert.Equal(expected, Regex.Replace(input, pattern, evaluator));
+                    success = Regex.TryReplace(input.AsSpan(), pattern, evaluator, output, out charsWritten);
+                    SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
                 }
                 if (isDefaultStart)
                 {
-                    // Use Replace(string, MatchEvaluator, string, int)
+                    // Use Replace(string, MatchEvaluator, string, int) & TryReplace(Span, MatchEvaluator, Span, out int, int)
                     Assert.Equal(expected, new Regex(pattern).Replace(input, evaluator, count));
+                    success = new Regex(pattern).TryReplace(input.AsSpan(), evaluator, output, out charsWritten, count);
+                    SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
                 }
+
                 // Use Replace(string, MatchEvaluator, int, int)
                 Assert.Equal(expected, new Regex(pattern).Replace(input, evaluator, count, start));
             }
             if (isDefaultStart && isDefaultCount)
             {
-                // Use Replace(string, MatchEvaluator) or Replace(string, MatchEvaluator, RegexOptions)
+                // Use Replace(string, MatchEvaluator) & TryReplace(Span, MatchEvaluator, Span, out int)
                 Assert.Equal(expected, new Regex(pattern, options).Replace(input, evaluator));
+                success = new Regex(pattern, options).TryReplace(input.AsSpan(), evaluator, output, out charsWritten);
+                SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
+
+                // Use Replace(string, MatchEvaluator, RegexOptions) & TryReplace(Span, string, MatchEvaluator, Span, out int, RegexOptions)
                 Assert.Equal(expected, Regex.Replace(input, pattern, evaluator, options));
+                success = Regex.TryReplace(input.AsSpan(), pattern, evaluator, output, out charsWritten, options);
+                SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
             }
             if (isDefaultStart)
             {
-                // Use Replace(string, MatchEvaluator, string, int)
+                // Use Replace(string, MatchEvaluator, string, int) & TryReplace(Span, MatchEvaluator, Span, out int, int)
                 Assert.Equal(expected, new Regex(pattern, options).Replace(input, evaluator, count));
+                success = new Regex(pattern, options).TryReplace(input.AsSpan(), evaluator, output, out charsWritten, count);
+                SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
             }
             // Use Replace(string, MatchEvaluator, int, int)
             Assert.Equal(expected, new Regex(pattern, options).Replace(input, evaluator, count, start));
@@ -219,9 +260,18 @@ namespace System.Text.RegularExpressions.Tests
         [Fact]
         public void Replace_NoMatch()
         {
-            string input = "";
-            Assert.Same(input, Regex.Replace(input, "no-match", "replacement"));
-            Assert.Same(input, Regex.Replace(input, "no-match", new MatchEvaluator(MatchEvaluator1)));
+            string expected = "";
+            Span<char> output = stackalloc char[255];
+
+            // Use Replace(string, string, string) & TryReplace(Span, string, string, Span, out int)
+            Assert.Same(expected, Regex.Replace(expected, "no-match", "replacement"));
+            bool success = Regex.TryReplace(expected.AsSpan(), "no-match", "replacement", output, out int charsWritten);
+            SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
+
+            // Use Replace(string, string, MatchEvaluator) & TryReplace(Span, string, MatchEvaluator, Span, out int)
+            Assert.Same(expected, Regex.Replace(expected, "no-match", new MatchEvaluator(MatchEvaluator1)));
+            success = Regex.TryReplace(expected.AsSpan(), "no-match", new MatchEvaluator(MatchEvaluator1), output, out charsWritten);
+            SpanTestHelpers.VerifySpan(expected, output, charsWritten, success);
         }
 
         [Fact]
@@ -246,29 +296,39 @@ namespace System.Text.RegularExpressions.Tests
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Replace("input", null, "replacement"));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Replace("input", null, "replacement", RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Replace("input", null, "replacement", RegexOptions.None, TimeSpan.FromMilliseconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.TryReplace("input".AsSpan(), null, "replacement", default, out _, RegexOptions.None, TimeSpan.FromMilliseconds(1)));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Replace("input", null, new MatchEvaluator(MatchEvaluator1)));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Replace("input", null, new MatchEvaluator(MatchEvaluator1), RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.Replace("input", null, new MatchEvaluator(MatchEvaluator1), RegexOptions.None, TimeSpan.FromMilliseconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("pattern", () => Regex.TryReplace("input".AsSpan(), null, new MatchEvaluator(MatchEvaluator1), default, out _, RegexOptions.None, TimeSpan.FromMilliseconds(1)));
 
             // Replacement is null
             AssertExtensions.Throws<ArgumentNullException>("replacement", () => Regex.Replace("input", "pattern", (string)null));
             AssertExtensions.Throws<ArgumentNullException>("replacement", () => Regex.Replace("input", "pattern", (string)null, RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("replacement", () => Regex.Replace("input", "pattern", (string)null, RegexOptions.None, TimeSpan.FromMilliseconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("replacement", () => Regex.TryReplace("input".AsSpan(), "pattern", (string)null, default, out _, RegexOptions.None, TimeSpan.FromMilliseconds(1)));
             AssertExtensions.Throws<ArgumentNullException>("replacement", () => new Regex("pattern").Replace("input", (string)null));
+            AssertExtensions.Throws<ArgumentNullException>("replacement", () => new Regex("pattern").TryReplace("input".AsSpan(), (string)null, default, out _));
             AssertExtensions.Throws<ArgumentNullException>("replacement", () => new Regex("pattern").Replace("input", (string)null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("replacement", () => new Regex("pattern").TryReplace("input".AsSpan(), (string)null, default, out _, 0));
             AssertExtensions.Throws<ArgumentNullException>("replacement", () => new Regex("pattern").Replace("input", (string)null, 0, 0));
 
             AssertExtensions.Throws<ArgumentNullException>("evaluator", () => Regex.Replace("input", "pattern", (MatchEvaluator)null));
             AssertExtensions.Throws<ArgumentNullException>("evaluator", () => Regex.Replace("input", "pattern", (MatchEvaluator)null, RegexOptions.None));
             AssertExtensions.Throws<ArgumentNullException>("evaluator", () => Regex.Replace("input", "pattern", (MatchEvaluator)null, RegexOptions.None, TimeSpan.FromMilliseconds(1)));
+            AssertExtensions.Throws<ArgumentNullException>("evaluator", () => Regex.TryReplace("input".AsSpan(), "pattern", (MatchEvaluator)null, default, out _, RegexOptions.None, TimeSpan.FromMilliseconds(1)));
             AssertExtensions.Throws<ArgumentNullException>("evaluator", () => new Regex("pattern").Replace("input", (MatchEvaluator)null));
+            AssertExtensions.Throws<ArgumentNullException>("evaluator", () => new Regex("pattern").TryReplace("input".AsSpan(), (MatchEvaluator)null, default, out _));
             AssertExtensions.Throws<ArgumentNullException>("evaluator", () => new Regex("pattern").Replace("input", (MatchEvaluator)null, 0));
+            AssertExtensions.Throws<ArgumentNullException>("evaluator", () => new Regex("pattern").TryReplace("input".AsSpan(), (MatchEvaluator)null, default, out _, 0));
             AssertExtensions.Throws<ArgumentNullException>("evaluator", () => new Regex("pattern").Replace("input", (MatchEvaluator)null, 0, 0));
 
             // Count is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => new Regex("pattern").Replace("input", "replacement", -2));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => new Regex("pattern").TryReplace("input".AsSpan(), "replacement", default, out _, - 2));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => new Regex("pattern").Replace("input", "replacement", -2, 0));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => new Regex("pattern").Replace("input", new MatchEvaluator(MatchEvaluator1), -2));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => new Regex("pattern").TryReplace("input".AsSpan(), new MatchEvaluator(MatchEvaluator1), default, out _, -2));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => new Regex("pattern").Replace("input", new MatchEvaluator(MatchEvaluator1), -2, 0));
 
             // Start is invalid

--- a/src/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
+++ b/src/System.Text.RegularExpressions/tests/Regex.Split.Tests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -110,6 +111,31 @@ namespace System.Text.RegularExpressions.Tests
             // Start is invalid
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startat", () => new Regex("pattern").Split("input", 0, -1));
             AssertExtensions.Throws<ArgumentOutOfRangeException>("startat", () => new Regex("pattern").Split("input", 0, 6));
+        }
+
+        [Theory]
+        [MemberData(nameof(Split_NonCompiled_TestData))]
+        public void Split_Span(string pattern, string input, RegexOptions options, int count, int start, string[] expected)
+        {
+            // Skip startat modification tests as we don't support startat with Span.
+            // Could change depending on decision made in API review.
+            // Discussion: https://github.com/ViktorHofer/corefx/pull/1#discussion_r172919687
+            if (start != 0 || ((options & RegexOptions.RightToLeft) != 0 && start != input.Length))
+                return;
+
+            // If RTL mode is chosen the enumerator returns the splits in the order right to left.
+            // That's different than in other API calls where RTL only applies to the search direction
+            // but not to the interpretation. More info: https://github.com/dotnet/corefx/issues/28056
+            // Need to be discussed in API review.
+            string[] exp = ((options & RegexOptions.RightToLeft) != 0) ? expected.Reverse().ToArray() : expected;
+
+            Regex.SplitEnumerator regexSplitEnumerator = new Regex(pattern, options).Split(input.AsSpan(), count);
+            int i = 0;
+            foreach (ReadOnlySpan<char> span in regexSplitEnumerator)
+            {
+                Assert.Equal(exp[i], span.ToString());
+                i++;
+            }
         }
     }
 }

--- a/src/System.Text.RegularExpressions/tests/SpanTestHelper.cs
+++ b/src/System.Text.RegularExpressions/tests/SpanTestHelper.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    internal static class SpanTestHelpers
+    {
+        public static void VerifySpan(string expected, Span<char> output, int charsWritten, bool success)
+        {
+            Assert.True(success);
+            Assert.Equal(expected.Length, charsWritten);
+            Assert.Equal(expected, output.Slice(0, charsWritten).ToString());
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
+++ b/src/System.Text.RegularExpressions/tests/System.Text.RegularExpressions.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="..\src\System\Text\RegularExpressions\RegexParseError.cs">
       <Link>System\Text\RegularExpressions\RegexParseError.cs</Link>
     </Compile>
+    <Compile Include="SpanTestHelper.cs" />
     <ProjectReference Include="$(CommonTestPath)\System\Diagnostics\RemoteExecutorConsoleApp\RemoteExecutorConsoleApp.csproj">
       <Name>RemoteExecutorConsoleApp</Name>
     </ProjectReference>


### PR DESCRIPTION
Related: https://github.com/dotnet/corefx/issues/24145

**Reviewers please read this first:**

## Implement & expose new Span/Memory APIs
**The APIs aren't approved by or even submitted to the API review board yet. I had to make sure that what I had planned was even possible before taking it to the board. That's why this PR targets my master branch and not the corefx's one.**

I introduced Span/Memory in places where it makes most sense.

Memory overloads: `Match`, `Matches` (return the provided input text in the Match object)
Span overloads: `Escape`, `IsMatch`, `Replace`, `Match.Result`

Replace with a MatchEvaluator is a special situation as the evaluator allows to reference members in the internal used Match object. As we are using a "light version" of Match (we are not setting the input Memory to avoid conversion from Span to Memory) for APIs that operate but not return a Match object, a "full" Match must be created here. To avoid copy costs from Span to Memory I'm pinning the Span for the lifetime of the Replace operation until the evaluation is done.

## Break inheritance between RegexInterpreter and RegexRunner
I was discussing this with Stephen before. The current architecture makes it hard/impossible to modernize the Interpreter and introduce goodies like Span/MemoryPool because RegexRunner itself is exposed because of the CompileToAssembly functionality, which we currently don't support in Core. As the Interpreter itself is internal it makes sense to get rid of this burden and modernize it.

Currently the relevant code is copied from RegexRunner to RegexInterpreter but I play with idea of changing it to a by ref type and introduce ValueListBuilder members for the stacks. This should remove a lot of duplicate code. More about that later. **Therefore please do yourself a favor and skip reviewing the code additions in RegexInterpreter.cs!**

The CompiledRunner currently boxes the input string to a Memory when creating the Match object. We are limited with introducing changes here and I plan to discuss breaking compatibility with netfx for assemblies that were compiled with CompileToAssembly. More about that later, not part of this discussion/PR.

## Tests
I added tests for the new overloads in all places where the string counterpart were used. As the string and the Span/Memory overloads share the same implementation, coverage should be fine. If you find any holes, please let me know.

## Minor changes
- Replace code paths especially for RTL optimized by avoiding an additional data structure for the reversed transformed inputs
- Add missing xmldocs to exposed APIs where it was missing

## Performance
Early Perfview/BenchmarkDotNet tests show that the existing string overloads benefit from the changes and aren't slower than they were before. More benchmarks and traces will follow soon!

I played with various inputs i.e. the regex-redux benchmark. After hacking the Shared ArrayPool<char> (resizing the max array size) I could see with Perfview that 99% of the string GC cleanup was removed and replaced by borrowed char arrays which of course currently don't get cleaned up: https://github.com/dotnet/coreclr/issues/7747.

## API Review
### Ref struct for Match and siblings (Capture & Group).

I had a discussion with Jan offline and he pointed out that we might want to introduce a `ref struct MatchValue` type that is returned by APIs that take Span/Memory as an input. 

> The problem with just using the current `class Match` is that it gives you unsecure access to the Span. For example, you can send the Match object to other thread and start working on the Span there, while the current thread unwinds and frees the memory.
ref struct MatchValue would avoid this issue
(And also saved the alllocation)

The issues with that is that we currently have the following hiearchy: Match --> Group --> Capture and that Groups and Match contain collections of Captures/Groups.

> Yes, the flip from class to valuetype tends to be like this. E.g. when we have introduced ValueTask to CoreFX, a bunch of parallel ValueSomething types went with it.
It is a topic for API review discussion
One option is to just not have Span version of the APIs that returns these collections or have callbacks

### startat overload

> For things like Regex.Replace, the startat argument means copy everything up to startat to the destination Span, and then run regular Replace that does not take startat method. So this looks like a convenience method to me - it saves you from typing a tiny bit of code in rare cases to achieve the same effect.

Should we add these startat convenience overloads for Span also?
If yes, this commit should be reverted https://github.com/ViktorHofer/corefx/pull/1/commits/bf7d7f986faaa212476ceeac09ab71c8ab6c7fd5

### RegexSplitEnumerator RTL yield order

If you call the Span version of Regex.Split and pass `RegexOptions.RightToLeft` to it the yield order of the enumerator will also be right to left as we start looking for matches from right to left. The current implementation (which is not an enumerator!) reverses the captured strings before returning.

### RegexSplitEnumerator GetEnumerator (see ref diff)
> I'm not aware of any other cases in the BCL where we have a GetEnumerator method like this on a struct enumerator. I understand you want it to be able to directly foreach the results without introducing an enumerable struct to serve as the return type, but I'm not sure this is a pattern we want to introduce. You should be sure to highlight this as part of any API review discussion.

### Proposed APIs
This diff contains the Memory overloads and the MatchEvaluator overloads. See discussion above if we should introduce new ref types for Match, Group & Capture.
```diff
namespace System.Text.RegularExpressions
{
    public partial class Capture
    {
        internal Capture() { }
        public int Index { get { throw null; } }
        public int Length { get { throw null; } }
        public string Value { get { throw null; } }
+       public ReadOnlySpan<char> ValueSpan { get { throw null; } }
        public override string ToString() { throw null; }
    }
    public partial class Match : System.Text.RegularExpressions.Group
    {
        internal Match() { }
        public static System.Text.RegularExpressions.Match Empty { get { throw null; } }
        public virtual System.Text.RegularExpressions.GroupCollection Groups { get { throw null; } }
        public System.Text.RegularExpressions.Match NextMatch() { throw null; }
        public virtual string Result(string replacement) { throw null; }
+       public virtual bool TryResult(string replacement, Span<char> destination, out int charsWritten) { throw null; }
        public static System.Text.RegularExpressions.Match Synchronized(System.Text.RegularExpressions.Match inner) { throw null; }
    }
    public partial class Regex : System.Runtime.Serialization.ISerializable
    {
+       public ref struct SplitEnumerator
+       {
+           public ReadOnlySpan<char> Current { get { throw null; } }
+           public SplitEnumerator GetEnumerator() { throw null; }
+           public bool MoveNext() { throw null; }
+       }
        protected internal System.Collections.Hashtable caps;
        protected internal System.Collections.Hashtable capnames;
        protected internal int capsize;
        protected internal string[] capslist;
        protected internal System.Text.RegularExpressions.RegexRunnerFactory factory;
        public static readonly System.TimeSpan InfiniteMatchTimeout;
        protected internal System.TimeSpan internalMatchTimeout;
        protected internal string pattern;
        protected internal System.Text.RegularExpressions.RegexOptions roptions;
        protected Regex() { }
        protected Regex(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
        public Regex(string pattern) { }
        public Regex(string pattern, System.Text.RegularExpressions.RegexOptions options) { }
        public Regex(string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { }
        public static int CacheSize { get { throw null; } set { } }
        [System.CLSCompliant(false)]
        protected System.Collections.IDictionary Caps { get { throw null; } set { } }
        [System.CLSCompliant(false)]
        protected System.Collections.IDictionary CapNames { get { throw null; } set { } }
        public System.TimeSpan MatchTimeout { get { throw null; } }
        public System.Text.RegularExpressions.RegexOptions Options { get { throw null; } }
        public bool RightToLeft { get { throw null; } }
        public static string Escape(string str) { throw null; }
+       public static bool TryEscape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten) { throw null; }
        public string[] GetGroupNames() { throw null; }
        public int[] GetGroupNumbers() { throw null; }
        public string GroupNameFromNumber(int i) { throw null; }
        public int GroupNumberFromName(string name) { throw null; }
        protected void InitializeReferences() { }
        public bool IsMatch(string input) { throw null; }
+       public bool IsMatch(ReadOnlySpan<char> input) { throw null; }
        public bool IsMatch(string input, int startat) { throw null; }
        public static bool IsMatch(string input, string pattern) { throw null; }
        public static bool IsMatch(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
        public static bool IsMatch(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+       public static bool IsMatch(ReadOnlySpan<char> input, string pattern, System.Text.RegularExpressions.RegexOptions options = System.Text.RegularExpressions.RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
        public System.Text.RegularExpressions.Match Match(string input) { throw null; }
+       public System.Text.RegularExpressions.Match Match(ReadOnlyMemory<char> input) { throw null; }
        public System.Text.RegularExpressions.Match Match(string input, int startat) { throw null; }
        public System.Text.RegularExpressions.Match Match(string input, int beginning, int length) { throw null; }
        public static System.Text.RegularExpressions.Match Match(string input, string pattern) { throw null; }
        public static System.Text.RegularExpressions.Match Match(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
        public static System.Text.RegularExpressions.Match Match(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+       public static System.Text.RegularExpressions.Match Match(ReadOnlyMemory<char> input, string pattern, System.Text.RegularExpressions.RegexOptions options = RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
        public System.Text.RegularExpressions.MatchCollection Matches(string input) { throw null; }
+       public System.Text.RegularExpressions.MatchCollection Matches(ReadOnlyMemory<char> input) { throw null; }
        public System.Text.RegularExpressions.MatchCollection Matches(string input, int startat) { throw null; }
        public static System.Text.RegularExpressions.MatchCollection Matches(string input, string pattern) { throw null; }
        public static System.Text.RegularExpressions.MatchCollection Matches(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
        public static System.Text.RegularExpressions.MatchCollection Matches(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+       public static System.Text.RegularExpressions.MatchCollection Matches(ReadOnlyMemory<char> input, string pattern, System.Text.RegularExpressions.RegexOptions options = RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
        public string Replace(string input, string replacement) { throw null; }
        public string Replace(string input, string replacement, int count) { throw null; }
+       public bool TryReplace(ReadOnlySpan<char> input, string replacement, Span<char> destination, out int charsWritten, int count = -1) { throw null; }
        public string Replace(string input, string replacement, int count, int startat) { throw null; }
        public static string Replace(string input, string pattern, string replacement) { throw null; }
        public static string Replace(string input, string pattern, string replacement, System.Text.RegularExpressions.RegexOptions options) { throw null; }
        public static string Replace(string input, string pattern, string replacement, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+       public static bool TryReplace(ReadOnlySpan<char> input, string pattern, string replacement, Span<char> destination, out int charsWritten, System.Text.RegularExpressions.RegexOptions options = System.Text.RegularExpressions.RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
        public static string Replace(string input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator) { throw null; }
        public static string Replace(string input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator, System.Text.RegularExpressions.RegexOptions options) { throw null; }
        public static string Replace(string input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+       public static bool TryReplace(ReadOnlySpan<char> input, string pattern, System.Text.RegularExpressions.MatchEvaluator evaluator, Span<char> destination, out int charsWritten, System.Text.RegularExpressions.RegexOptions options = System.Text.RegularExpressions.RegexOptions.None, System.TimeSpan? matchTimeout = null) { throw null; }
        public string Replace(string input, System.Text.RegularExpressions.MatchEvaluator evaluator) { throw null; }
        public string Replace(string input, System.Text.RegularExpressions.MatchEvaluator evaluator, int count) { throw null; }
+       public bool TryReplace(ReadOnlySpan<char> input, System.Text.RegularExpressions.MatchEvaluator evaluator, Span<char> destination, out int charsWritten, int count = -1) { throw null; }
        public string Replace(string input, System.Text.RegularExpressions.MatchEvaluator evaluator, int count, int startat) { throw null; }
        public string[] Split(string input) { throw null; }
        public string[] Split(string input, int count) { throw null; }
        public string[] Split(string input, int count, int startat) { throw null; }
+       public SplitEnumerator Split(ReadOnlySpan<char> input, int count = 0) { throw null; }
        public static string[] Split(string input, string pattern) { throw null; }
        public static string[] Split(string input, string pattern, System.Text.RegularExpressions.RegexOptions options) { throw null; }
        public static string[] Split(string input, string pattern, System.Text.RegularExpressions.RegexOptions options, System.TimeSpan matchTimeout) { throw null; }
+       public static SplitEnumerator Split(ReadOnlySpan<char> input, string pattern, RegexOptions options = RegexOptions.None, TimeSpan? matchTimeout = null) { throw null; }
        void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { }
        public override string ToString() { throw null; }
        public static string Unescape(string str) { throw null; }
+       public static bool TryUnescape(ReadOnlySpan<char> str, Span<char> destination, out int charsWritten) { throw null; }
        protected bool UseOptionC() { throw null; }
        protected bool UseOptionR() { throw null; }
        protected internal static void ValidateMatchTimeout(System.TimeSpan matchTimeout) { }
    }
}
```